### PR TITLE
[G2M] Buttons/border radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -86,7 +86,8 @@ const Button = ({ children, classes, variant, size, type, disabled, ...rest }) =
 
   const _classes = {
     button: clsx(
-      `focus:outline-none rounded-sm font-normal ${sizes.text[size]} ${variants[variant]} ${classes.button}`,
+      `focus:outline-none ${classes.button.borderRadius || 'rounded-sm'}
+      font-normal ${sizes.text[size]} ${variants[variant]} ${classes.button}`,
       {
         [sizes[size]]: typeof children === 'string',
         [sizes.squared[size]]: typeof children !== 'string',

--- a/stories/buttons/button-story.js
+++ b/stories/buttons/button-story.js
@@ -55,6 +55,16 @@ const ButtonStory = ({ variant }) => {
         <Button variant={variant} size='sm' type='error'>Error</Button>
         <Button disabled variant={variant} size='sm'>Disabled</Button>
       </div>
+
+      <div>
+        <p className={styles.label}>Customized border-radius:</p>
+        <span className='flex flex-row justify-start items-center'>
+          <Button classes={{ button: { borderRadius: 'rounded-r-sm mr-10' } }} variant={variant} size='lg'>Button</Button>
+          <Button classes={{ button: { borderRadius: 'rounded-l-sm mr-10' } }} variant={variant} size='lg'>Button</Button>
+          <Button classes={{ button: { borderRadius: 'rounded-t-sm mr-10' } }} variant={variant} size='lg'>Button</Button>
+          <Button classes={{ button: { borderRadius: 'rounded-b-sm' } }} variant={variant} size='lg'>Button</Button>
+        </span>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
Continuation of #50 
[Storybook published for this branch.](https://60d0cd6c298707003972699d-ypaifqyici.chromatic.com/?path=/story/buttons--outlined)

**Changes include:**
- add classname to configure border-radius for each button variant

**Screenshots:**
<img width="498" alt="Screen Shot 2021-09-14 at 12 38 15 PM" src="https://user-images.githubusercontent.com/50936670/133298401-4835465a-4573-4aee-9eea-7b2eb5f0ea2a.png">
**Use case scenario:**
- one sided border-radius for this select button
<img width="812" alt="Screen Shot 2021-09-14 at 12 39 36 PM" src="https://user-images.githubusercontent.com/50936670/133298593-2ace3084-1f86-41c0-885a-455b9a6386c4.png">
