### PR TITLE
[G2M] TextField - pass input as onSubmit event target

### DIFF
--- a/src/components/text-field.js
+++ b/src/components/text-field.js
@@ -98,7 +98,7 @@ const TextField  = ({ classes, size, inputProps, label, maxLength, helperText, s
         <p className={textFieldClasses.label}>{label}</p>
         {required && <span className='flex flex-row ml-5px text-error-500'>*</span>}
       </div>}
-      <form onSubmit={onSubmit}>
+      <form onSubmit={(e) => onSubmit({ ...e, target: e.target.children[0].children[0] })}>
         <InputBase
           {...inputProps}
           classes={inputBaseClasses}


### PR DESCRIPTION
This change would allow devs to use `TextField` more intuitively, i.e. 
```jsx
          <TextField
            onSubmit={(e) => {
              doSomething(e.target.value)
              e.preventDefault()
            }}
          />
```
instead of
```jsx
          <TextField
            onSubmit={(e) => {
              doSomething(e.target.children[0].children[0].value)
              e.preventDefault()
            }}
          />
```

Maybe this is intended behaviour; if so, I can close this.

The underlying `input` element should always be the only child of the `TextField`, unless you actually place children inside `TextField` which seems like something that would never happen anyway. If this is a concern, I can add a verification step that ensures `e.target.children[0].children[0]` is in fact an `input` element. 

PS: Haven't been able to test this because I'm having strange troubles `yarn link`ing the library, but it should work..?