### PR TITLE
[G2M] Accordion - point icon to the right when collapsed

### DIFF
--- a/src/base-components/accordion-base/panel-base.js
+++ b/src/base-components/accordion-base/panel-base.js
@@ -11,9 +11,8 @@ const PanelBase = React.forwardRef(({ children, classes, id, header, ExpandIcon,
       return (
         <span className={`${classes.iconRoot}`}>
           <Icon className={clsx(`${classes.icon} transition-transform duration-300 ease-in-out origin-center transform`, {
-            '-rotate-180': open.includes(id) && alignIcon === 'start',
-            'rotate-180': open.includes(id) && alignIcon === 'end',
-            'rotate-0': !open.includes(id),
+            'rotate-0': open.includes(id),
+            '-rotate-90': !open.includes(id),
           })} />
         </span>
       )


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/53827672/139466241-07c29295-66c7-4070-8158-c1ed780778a8.png)

after
![image](https://user-images.githubusercontent.com/53827672/139466183-2ce5c5fc-8fad-4f19-ae4a-e834a7ba7251.png)

Per discussion with @sallkall 