### PR TITLE
[G2M] Tooltip/error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src stories",
     "lint:watch:fix": "esw --fix --watch src stories",
     "build": "babel src --out-dir dist --copy-files",
+    "watch": "babel src -w --out-dir dist --copy-files",
     "build-storybook": "build-storybook",
     "build-tailwindcss": "npx postcss src/styles/tailwind.css -o src/styles/index.css",
     "build-tailwindcss-prod": "NODE_ENV=production npx postcss src/styles/tailwind.css -o src/styles/index.css",

--- a/src/components/tooltip.js
+++ b/src/components/tooltip.js
@@ -59,7 +59,7 @@ const Tooltip = ({
   const handleMouseEnter = () => {
     const tooltipEl = tooltipRef.current.getElementsByClassName('tooltip')
     timeOut = setTimeout(() => {
-      tooltipEl.forEach(el => {
+      Array.from(tooltipEl).forEach(el => {
         el.style.visibility = 'visible'
         el.style.opacity = 1
       })
@@ -68,7 +68,7 @@ const Tooltip = ({
 
   const handleMouseLeave = () => {
     const tooltipEl = tooltipRef.current.getElementsByClassName('tooltip')
-    tooltipEl.forEach(el => {
+    Array.from(tooltipEl).forEach(el => {
       el.style.visibility = 'hidden'
       el.style.opacity = 0
     })


### PR DESCRIPTION
without this fix I get an error that prevents the tooltip from rendering:
![image](https://user-images.githubusercontent.com/53827672/139556070-891bb01f-195a-4942-85c6-898ff2ce402d.png)
The error is due to the fact that `tooltipEl` is an `HTMLCollection` and as such needs to be coerced into an array before using `Array` prototype methods on it like `forEach`.

I have no idea why the Tooltips work without the fix in the `lumen-labs` storybook. Maybe something with the babel config.....?? :shrug: 

---

Also added `yarn watch` script for easy `yarn link`ing.