### PR TITLE
[G2M] Accordion/auto height

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "clsx": "^1.1.1",
     "goober": "^2.0.39",
     "prop-types": "^15.7.2",
+    "react-resize-detector": "^6.7.6",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6"
   }

--- a/src/base-components/accordion-base/panel-base.js
+++ b/src/base-components/accordion-base/panel-base.js
@@ -6,14 +6,14 @@ import { useResizeDetector } from 'react-resize-detector'
 
 const PanelBase = React.forwardRef(({ children, classes, id, header, ExpandIcon, CompressIcon, alignIcon, open, setOpen, onChange, autoHeight }, ref) => {
   const detailsNoHeight = classes.details?.split(/\bh-\w+|\bp-\w+|\bpy-\w+/).map((r) => r.trim()).filter((r) => r).join(' ')
-  const Icon = open.includes(id) ? ExpandIcon : CompressIcon ? CompressIcon : ExpandIcon
+  const Icon = open.includes(id) ? ExpandIcon : CompressIcon ?? ExpandIcon
   const renderIcon = () => {
     if (Icon) {
       return (
         <span className={`${classes.iconRoot}`}>
           <Icon className={clsx(`${classes.icon} transition-transform duration-300 ease-in-out origin-center transform`, {
             'rotate-0': open.includes(id),
-            '-rotate-90': !open.includes(id),
+            '-rotate-90': !open.includes(id) && !CompressIcon,
           })} />
         </span>
       )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,10 @@ module.exports = {
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
-      transitionProperty: { height: 'height, background-color, padding, margin' },
+      transitionProperty: {
+        height: 'height, background-color, padding, margin',
+        'max-height': 'max-height',
+      },
       colors: {
         'primary-50': '#eff8fe',
         'primary-100': '#d6e8fd',
@@ -24,7 +27,7 @@ module.exports = {
         'primary-700': '#1b3ea4',
         'primary-800': '#112b84',
         'primary-900': '#0a1d6d',
-  
+
         'secondary-50': '#fefefe',
         'secondary-100': '#f7f7f7',
         'secondary-200': '#f2f2f2',
@@ -44,7 +47,7 @@ module.exports = {
         'neutral-500': '#4a5c8c',
         'neutral-600': '#2c3d74',
         'neutral-700': '#202e63',
-    
+
         'interactive-50': 'rgba(238, 250, 254, 0.87)',
         'interactive-100': '#d5ecfc',
         'interactive-200': '#add6fa',
@@ -89,8 +92,8 @@ module.exports = {
         'info-500': '#666cc6',
         'info-600': '#4a4faa',
         'info-700': '#33378e',
-        
-        
+
+
         success: '#00D308',
         'success-hover': '#00b306',
         'success-light': '#EEF8EE',
@@ -117,19 +120,19 @@ module.exports = {
         '15px': '0.938rem',
         '18px': '1.125rem',
         '42px': '2.625rem',
-        '250px': '15.625rem', 
+        '250px': '15.625rem',
         '300px': '18.75rem',
-        '450px': '28.125rem', 
+        '450px': '28.125rem',
         '500px': '31.25rem',
         '600px': '37.5rem',
         '760px': '47.5rem',
         '1000px': '62.5rem',
       },
-      borderRadius: { 
-        sm: '4px', 
-        md: '0.375rem', 
-        xl: '0.75rem', 
-        '10px': '0.625rem', 
+      borderRadius: {
+        sm: '4px',
+        md: '0.375rem',
+        xl: '0.75rem',
+        '10px': '0.625rem',
       },
       boxShadow: {
         'focused-primary': '0 0 2px 2px rgba(0, 117, 255, 0.25)',
@@ -154,8 +157,8 @@ module.exports = {
         'blue-60': '0px 4px 24px rgba(54, 111, 228, 0.1)',
         'dark-10': '-1px 0 4px 0 rgba(81, 113, 151, 0.1), 1px 0 4px 0 rgba(81, 113, 151, 0.1), 0 -1px 4px 0 rgba(81, 113, 151, 0.1), 0 1px 4px 0 rgba(81, 113, 151, 0.1)',
       },
-      fontSize: { 
-        xxs: ['0.625rem', { lineHeight: '1rem' }], 
+      fontSize: {
+        xxs: ['0.625rem', { lineHeight: '1rem' }],
         '11px': ['0.688rem', { lineHeight: 1.45 }],
       },
       letterSpacing: {
@@ -231,7 +234,7 @@ module.exports = {
       64: '16rem',
       72: '18rem',
       80: '20rem',
-      96: '24rem',      
+      96: '24rem',
     },
     animation: {
       none: 'none',
@@ -1048,7 +1051,7 @@ module.exports = {
     zIndex: ['responsive', 'focus-within', 'focus'],
   },
   plugins: [
-    function({ addUtilities, theme }) {
+    function ({ addUtilities, theme }) {
 
       let newUtilities = {}
       const boxShadowPrefix = '0 0 0 1px'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2333,6 +2333,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/resize-observer-browser@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz#d8e6c2f830e2650dc06fe74464472ff64b54a302"
+  integrity sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg==
+
 "@types/scheduler@*":
   version "0.16.1"
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
@@ -6778,6 +6783,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -8497,6 +8507,16 @@ react-refresh@^0.8.3:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
+react-resize-detector@^6.7.6:
+  version "6.7.6"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-6.7.6.tgz#4416994e5ead7eba76606e3a248a1dfca49b67a3"
+  integrity sha512-/6RZlul1yePSoYJxWxmmgjO320moeLC/khrwpEVIL+D2EjLKhqOwzFv+H8laMbImVj7Zu4FlMa0oA7au3/ChjQ==
+  dependencies:
+    "@types/resize-observer-browser" "^0.1.6"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    resize-observer-polyfill "^1.5.1"
+
 react-sizeme@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.1.tgz#4d12f4244e0e6a0fb97253e7af0314dc7c83a5a0"
@@ -8818,6 +8838,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-from@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Addresses #58 in which `details` height does not transition when its desired height is not explicitly stated.

I ended up making this behaviour optional with the `autoHeight` prop in `Accordion.Panel`, as it was breaking normal behaviour in the storybook. I'm pretty sure this behaviour is preferable in most cases, but figured we should preserve the existing functionality for backwards compatibility.

before:

https://user-images.githubusercontent.com/53827672/139756313-610a0641-2e0c-4c3f-946a-415d8842438d.mp4

after:

https://user-images.githubusercontent.com/53827672/139756013-580982f3-1ce9-429f-b10d-f584317f8c4b.mp4