### PR TITLE
[G2M] Accordion - no default color, syntax adjustment

### DIFF
--- a/src/base-components/accordion-base/panel-base.js
+++ b/src/base-components/accordion-base/panel-base.js
@@ -49,23 +49,16 @@ const PanelBase = React.forwardRef(({ children, classes, id, header, ExpandIcon,
         <span className='inline-block align-baseline'>{header}</span>
         {alignIcon === 'end' && renderIcon()}
       </div>
-      {
-        autoHeight
-          ? <div
-            ref={detailsRef}
-            className={clsx('bg-red-200 transition-max-height ease-in-out duration-300 overflow-y-hidden', {
-              [`${classes.details} max-h-full`]: open.includes(id),
-              [`${classes.details} max-h-0`]: !open.includes(id),
-            })}>
-            {children}
-          </div>
-          : <div className={clsx('transition-height ease-in-out duration-300 overflow-y-hidden', {
-            [classes.details]: open.includes(id),
-            [`${detailsNoHeight} h-0`]: !open.includes(id),
-          })}>
-            {children}
-          </div>
-      }
+      <div
+        ref={autoHeight ? detailsRef : null}
+        className={clsx('transition-max-height ease-in-out duration-300 overflow-y-hidden', {
+          [`${classes.details} max-h-full`]: autoHeight && open.includes(id),
+          [`${classes.details} max-h-0`]: autoHeight && !open.includes(id),
+          [classes.details]: !autoHeight && open.includes(id),
+          [`${detailsNoHeight} h-0`]: !autoHeight && !open.includes(id),
+        })}>
+        {children}
+      </div>
     </div>
   )
 })


### PR DESCRIPTION
oops - added a red background to the collapsible section of `Accordion` in #62. Also took the opportunity to reduce code duplication in this part of the component.