### PR TITLE
[G2M] DropdownSelect - allow continual setSelectedOption

### DIFF
--- a/src/components/dropdown-auto-center/index.js
+++ b/src/components/dropdown-auto-center/index.js
@@ -9,7 +9,7 @@ const DropdownAutoCenter = forwardRef(({
   classes, 
   data,
   onSelect,
-  setSelectedOption,
+  value,
   startIcon,
   endIcon,
   scrollable,
@@ -33,7 +33,7 @@ const DropdownAutoCenter = forwardRef(({
 
   const [open, setOpen] = useState(false)
   const [dropdownOffsetTop, setDropdownOffsetTop] = useState(0)
-  const [active, setActive] = useState(setSelectedOption || '')
+  const [active, setActive] = useState(value || '')
   const dropdownRef = useRef(null)
 
   useEffect(() => {
@@ -114,7 +114,7 @@ DropdownAutoCenter.propTypes = {
     }),
   ),
   onSelect: PropTypes.func,
-  setSelectedOption: PropTypes.any,
+  value: PropTypes.any,
   startIcon: PropTypes.node,
   endIcon: PropTypes.node,
   scrollable: PropTypes.bool,

--- a/src/components/dropdown-auto-complete.js
+++ b/src/components/dropdown-auto-complete.js
@@ -42,7 +42,7 @@ const DropdownAutoComplete = ({
   classes, 
   data, 
   size, 
-  setSelectedOption,
+  value,
   onSelect,
   onDelete, 
   inputProps, 
@@ -51,9 +51,9 @@ const DropdownAutoComplete = ({
   ...rest 
 }) => {
   const [options, setOptions] = useState(data)
-  const [selectedOptions, setSelectedOptions] = useState(setSelectedOption || {})
+  const [selectedOptions, setSelectedOptions] = useState(value || {})
   const [open, setOpen] = useState(false)
-  const [userInput, setUserInput] = useState(setSelectedOption ? setSelectedOption.title : '')
+  const [userInput, setUserInput] = useState(value ? value.title : '')
   const [filteredOptions, setFilteredOptions] = useState([])
   const { ref, componentIsActive, setComponentIsActive } = useComponentIsActive()
   const contentSize = _contentSize(size)
@@ -268,7 +268,7 @@ DropdownAutoComplete.propTypes = {
     }),
   ),
   size: PropTypes.string,
-  setSelectedOption: PropTypes.shape({
+  value: PropTypes.shape({
     title: PropTypes.string.isRequired,
   }),
   onSelect: PropTypes.func,

--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -63,7 +63,11 @@ const DropdownSelect = ({
   const [selectLimit, setSelectLimit] = useState(limit || 0)
   const [open, setOpen] = useState(false)
   const { ref, componentIsActive, setComponentIsActive } = useComponentIsActive()
-  
+
+  useEffect(() => {
+    setSelectedOptions(setSelectedOption || [])
+  }, [setSelectedOption])
+
   const contentSize = _contentSize(size)
   const dropdownSelectClasses = Object.freeze({
     listContainer: `capitalize ${classes.listContainer}`,

--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -44,7 +44,7 @@ const DropdownSelect = ({
   data, 
   button, 
   size, 
-  setSelectedOption,
+  value,
   onSelect, 
   onDelete,
   startIcon, 
@@ -59,14 +59,14 @@ const DropdownSelect = ({
   ...rest 
 }) => {
   const [options, setOptions] = useState([])
-  const [selectedOptions, setSelectedOptions] = useState(setSelectedOption || [])
+  const [selectedOptions, setSelectedOptions] = useState(value || (multiSelect ? [] : {}))
   const [selectLimit, setSelectLimit] = useState(limit || 0)
   const [open, setOpen] = useState(false)
   const { ref, componentIsActive, setComponentIsActive } = useComponentIsActive()
 
   useEffect(() => {
-    setSelectedOptions(setSelectedOption || [])
-  }, [setSelectedOption])
+    setSelectedOptions(value || (multiSelect ? [] : {}))
+  }, [value])
 
   const contentSize = _contentSize(size)
   const dropdownSelectClasses = Object.freeze({
@@ -300,7 +300,7 @@ DropdownSelect.propTypes = {
   ),
   button: PropTypes.node,
   size: PropTypes.string,
-  setSelectedOption: PropTypes.oneOfType([
+  value: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.object,
   ]),

--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -44,6 +44,8 @@ const DropdownSelect = ({
   data, 
   button, 
   size, 
+  uncontrolled,
+  defaultValue,
   value,
   onSelect, 
   onDelete,
@@ -59,13 +61,15 @@ const DropdownSelect = ({
   ...rest 
 }) => {
   const [options, setOptions] = useState([])
-  const [selectedOptions, setSelectedOptions] = useState(value || (multiSelect ? [] : {}))
+  const [selectedOptions, setSelectedOptions] = useState(defaultValue || value || (multiSelect ? [] : {}))
   const [selectLimit, setSelectLimit] = useState(limit || 0)
   const [open, setOpen] = useState(false)
   const { ref, componentIsActive, setComponentIsActive } = useComponentIsActive()
 
   useEffect(() => {
-    setSelectedOptions(value || (multiSelect ? [] : {}))
+    if (!uncontrolled) {
+      setSelectedOptions(value || (multiSelect ? [] : {}))
+    }
   }, [value])
 
   const contentSize = _contentSize(size)
@@ -300,6 +304,11 @@ DropdownSelect.propTypes = {
   ),
   button: PropTypes.node,
   size: PropTypes.string,
+  uncontrolled: PropTypes.bool,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+  ]),
   value: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.object,
@@ -334,6 +343,7 @@ DropdownSelect.defaultProps = {
   data: [],
   button: null,
   size: 'md',
+  uncontrolled: true,
   onSelect: () => {},
   onDelete: () => {},
   startIcon: null,

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -157,7 +157,7 @@ const Pagination = ({ classes, items, onChangePage, initialPage, pageSize, showP
             <DropdownAutoCenter 
               data={dropdownData} 
               onSelect={(val) => {setRowsPerPageSize(Number(val.title))}} 
-              setSelectedOption={{ title: pageSize }}
+              value={{ title: pageSize }}
               endIcon={<ArrowUpDown size='sm'/>}
             />
           </li>

--- a/stories/dropdown.stories.js
+++ b/stories/dropdown.stories.js
@@ -104,7 +104,7 @@ export const Base = () => {
  *    }
  * [button] - node, custom onClick element to trigger select/dropdown menu
  * [size] - string, control component size - supported sizes ['md', 'lg'], default = 'md'
- * [setSelectedOption] - array (multiSelect) / object (single), set initial selected option
+ * [value] - array (multiSelect) / object (single), set initial selected option
  * [placeholder] - string, helper value of input if value is empty
  * [onSelect] - function, returns selected value
  * [onDelete] - function, callback function on delete selected value
@@ -256,7 +256,7 @@ export const MultiSelect = () => {
  *      endIcon: node, icon on right side of divider title
  *    }
  * [size] - string, control component size - supported sizes ['md', 'lg'], default = 'md'
- * [setSelectedOption] - object, set initial selected option
+ * [value] - object, set initial selected option
  * [inputProps] - object, accepts all InputBase props
  * [onSelect] - function, returns selected value
  * [onDelete] - function, callback function on delete selected value
@@ -450,7 +450,7 @@ export const CustomButton = () => {
  * [data] - array, data json structure to render the item inside the dropdown
  *    title: string, name of the item
  * [onSelect] - function, returns selected value
- * [setSelectedOption] - any, set initial selected option
+ * [value] - any, set initial selected option
  * [startIcon] - node, icon on left side of select container
  * [endIcon] - node, icon on right side of select container
  * [scrollable] - bool, controls component y-axis scroll
@@ -465,7 +465,7 @@ export const DropdownCenterSelectedItem = () => {
         <div>No padding</div>
         <DropdownAutoCenter 
           data={sampleDataMultiselect[0].items} 
-          setSelectedOption={{ title: 'orange' }}
+          value={{ title: 'orange' }}
           endIcon={<ArrowUpDown size='sm'/>}
           scrollable
         />
@@ -474,7 +474,7 @@ export const DropdownCenterSelectedItem = () => {
         <div>With padding</div>
         <DropdownAutoCenter 
           data={sampleDataMultiselect[0].items} 
-          setSelectedOption={{ title: 'orange' }}
+          value={{ title: 'orange' }}
           endIcon={<ArrowUpDown size='sm'/>}
           scrollable
         />
@@ -483,7 +483,7 @@ export const DropdownCenterSelectedItem = () => {
         <div>With padding no scroll</div>
         <DropdownAutoCenter 
           data={sampleDataMultiselect[0].items} 
-          setSelectedOption={{ title: 'orange' }}
+          value={{ title: 'orange' }}
           endIcon={<ArrowUpDown size='sm'/>}
         />
       </div>
@@ -515,7 +515,7 @@ export const Disabled = () => {
         <p>Auto Center</p>
         <DropdownAutoCenter 
           data={sampleDataMultiselect[0].items} 
-          setSelectedOption={{ title: 'orange' }}
+          value={{ title: 'orange' }}
           endIcon={<ArrowUpDown size='sm'/>}
           disabled
         />

--- a/stories/dropdown.stories.js
+++ b/stories/dropdown.stories.js
@@ -104,7 +104,9 @@ export const Base = () => {
  *    }
  * [button] - node, custom onClick element to trigger select/dropdown menu
  * [size] - string, control component size - supported sizes ['md', 'lg'], default = 'md'
- * [value] - array (multiSelect) / object (single), set initial selected option
+ * [value] - array (multiSelect) / object (single), selected option(s) (serves as default value if uncontrolled)
+ * [uncontrolled] - bool, don't react to changes in value, default = false 
+ * [defaultValue] - array (multiSelect) / object (single), initial selected option 
  * [placeholder] - string, helper value of input if value is empty
  * [onSelect] - function, returns selected value
  * [onDelete] - function, callback function on delete selected value


### PR DESCRIPTION
without this adjustment, was unable to fully control the `DropdownSelect` (i.e. have it clear when it is passed an empty string as `setSelectedOption`). Seems like the `setSelectedOption` prop was only being used once at the beginning of the component's lifecycle.