### PR TITLE
[G2M] Dropdown/misc improvements

### DIFF
--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -182,18 +182,16 @@ const DropdownSelect = ({
   }
 
   const handleOnClick = (i, value) => {
-    let newSelectedOptions
+    let newSelectedOptions = []
     if (multiSelect) {
       newSelectedOptions = selectedOptions
       const currOptions = options
       const filterOptions = []
 
-      if (selectedOptions.some(({ title }) => title === value.title)) {
-        let index = selectedOptions.map(({ title }) => title).indexOf(value.title)
-        if (index !== -1) {
-          newSelectedOptions.splice(index, 1)
-          currOptions.push(value)
-        }
+      const index = selectedOptions.findIndex(({ title }) => title === value.title)
+      if (index != -1) {
+        newSelectedOptions.splice(index, 1)
+        currOptions.push(value)
       } else if (selectedOptions.length < selectLimit) {
         let index = options.map(({ title }) => title).indexOf(value.title)
         if (index !== -1) {

--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -182,21 +182,23 @@ const DropdownSelect = ({
   }
 
   const handleOnClick = (i, value) => {
+    let newSelectedOptions
     if (multiSelect) {
+      newSelectedOptions = selectedOptions
       const currOptions = options
       const filterOptions = []
 
       if (selectedOptions.some(({ title }) => title === value.title)) {
         let index = selectedOptions.map(({ title }) => title).indexOf(value.title)
         if (index !== -1) {
-          selectedOptions.splice(index, 1)
+          newSelectedOptions.splice(index, 1)
           currOptions.push(value)
         }
       } else if (selectedOptions.length < selectLimit) {
         let index = options.map(({ title }) => title).indexOf(value.title)
         if (index !== -1) {
           currOptions.splice(index, 1)
-          selectedOptions.push(value)
+          newSelectedOptions.push(value)
         }
       }
 
@@ -207,13 +209,14 @@ const DropdownSelect = ({
       setOptions(filterOptions)
     } else if (!multiSelect) {
       if (selectedOptions.title === value.title) {
-        setSelectedOptions([])
+        newSelectedOptions = []
       } else {
-        setSelectedOptions(value)
+        newSelectedOptions = value
         onClickSelect()
       }
     }
-    onSelect({ ...value, i })
+    setSelectedOptions(newSelectedOptions)
+    onSelect(newSelectedOptions)
   }
   
   const onClickClose = (e, value) => {

--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -6,6 +6,7 @@ import { DropdownBase } from '../base-components'
 import { Chip } from '../'
 import { Close, ValidationCheck, Delete } from '../icons'
 import { useComponentIsActive } from '../hooks'
+import clsx from 'clsx'
 
 
 const _contentSize = (size) => {
@@ -147,14 +148,10 @@ const DropdownSelect = ({
         onClick={() => handleOnClick(index, item)}
       >
         <div
-          className={`content-container-${index}
-                ${dropdownSelectClasses.contentContainer}
-                ${multiSelect ? 
-      selectedOptions && selectedOptions.includes(item) && dropdownSelectClasses.selected
-      :
-      selectedOptions && selectedOptions.title === item.title && dropdownSelectClasses.selected
-    } 
-              `}
+          className={clsx(`content-container-${index} ${dropdownSelectClasses.contentContainer}`, {
+            [dropdownSelectClasses.selected]: (multiSelect && selectedOptions.some(({ title }) => title === item.title)) || selectedOptions.title === item.title,
+          },
+          )}
         >
           {renderListItem(item)}
           {item.description && <div className={`description-container-${index} ${dropdownSelectClasses.description}`}>{item.description}</div>}

--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -154,7 +154,7 @@ const DropdownSelect = ({
           )}
         >
           {renderListItem(item)}
-          {item.description && <div className={`description-container-${index} ${dropdownSelectClasses.description}`}>{item.description}</div>}
+          {!simple && item.description && <div className={`description-container-${index} ${dropdownSelectClasses.description}`}>{item.description}</div>}
         </div>
       </div>,
     )
@@ -163,7 +163,7 @@ const DropdownSelect = ({
   const renderListItem = (item) => {
     let selected = null
 
-    if (multiSelect && size === 'lg' && selectedOptions.includes(item)) {
+    if (multiSelect && size === 'lg' && selectedOptions.some(({ title }) => title === item.title)) {
       selected = (
         <ValidationCheck size='lg'/>
       )
@@ -186,14 +186,14 @@ const DropdownSelect = ({
       const currOptions = options
       const filterOptions = []
 
-      if (selectedOptions.includes(value)) {
-        let index = selectedOptions.indexOf(value)
+      if (selectedOptions.some(({ title }) => title === value.title)) {
+        let index = selectedOptions.map(({ title }) => title).indexOf(value.title)
         if (index !== -1) {
           selectedOptions.splice(index, 1)
           currOptions.push(value)
         }
       } else if (selectedOptions.length < selectLimit) {
-        let index = options.indexOf(value)
+        let index = options.map(({ title }) => title).indexOf(value.title)
         if (index !== -1) {
           currOptions.splice(index, 1)
           selectedOptions.push(value)


### PR DESCRIPTION
- made some fixes to allow correct list item highlighting for selected items in a `multiSelect` `DropdownSelect`
  - used `clsx`, because dynamically assigning `className`s like this: https://github.com/EQWorks/lumen-labs/blob/e8e4d5d3a1a1b1c41e1ef2012c4006889e105f5f/src/components/dropdown-select.js#L146
    doesn't work, you end up with strings `undefined` or `false` or `true` instead of what you're expecting (you could use `clsx` or just ternary expressions where the falsy branch is an empty string)
- replaced instances of `selectedOptions.indexOf` and `selectedOptions.includes` with expressions that perform a shallow equality check on the `title` properties of the list item(s). 
  - `==` or `===` operators don't appear to work between object literals that are equal in value
  - i.e., `{ 'title':'myitem1' }` is not `==` or `===` to `{ 'title':'myitem1' }`
- changed the payload of `onSelect` when `multiSelect === true`. Now, the list of selected items is passed, rather than the single item that was just selected or deselected. Without this change it is impossible to reflect deselections outside of the `DropdownSelect` component, because the `onSelect` payload appears identical to the payload if you just selected the item that you deselected.