### PR TITLE
[G2M] dropdown - add allowClear prop

### DIFF
--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -55,6 +55,7 @@ const DropdownSelect = ({
   showType, 
   overflow, 
   disabled, 
+  allowClear,
   ...rest 
 }) => {
   const [options, setOptions] = useState([])
@@ -235,7 +236,15 @@ const DropdownSelect = ({
       open={open}
       size={size}
       startIcon={startIcon} 
-      endIcon={!multiSelect && selectedOptions.title ? <Delete size={size} onClick={(e) => onClickDelete(e)}/>: endIcon}
+      endIcon={
+        !multiSelect && selectedOptions.title
+          ? (
+            allowClear
+              ? <Delete size={size} onClick={(e) => onClickDelete(e)} />
+              : null
+          )
+          : endIcon
+      }
       placeholder={placeholder}
       multiSelect={multiSelect} 
       overflow={overflow}
@@ -301,6 +310,7 @@ DropdownSelect.propTypes = {
   showType: PropTypes.bool,
   overflow: PropTypes.oneOf(['horizontal', 'vertical']),
   disabled: PropTypes.bool,
+  allowClear: PropTypes.bool,
 }
 
 DropdownSelect.defaultProps = {
@@ -329,6 +339,7 @@ DropdownSelect.defaultProps = {
   showType: false,
   overflow: 'horizontal',
   disabled: false,
+  allowClear: true,
 }
 
 DropdownSelect.displayName = 'DropdownSelect'

--- a/stories/dropdown.stories.js
+++ b/stories/dropdown.stories.js
@@ -114,6 +114,7 @@ export const Base = () => {
  * [showType] - bool, control displaying items type label if exists, default - false
  * [overflow] - string, control selected options x & y overflow - supported values ['horizontal', 'vertical'], default = 'horizontal'
  * [disabled] - bool, disable component status, default = false 
+ * [allowClear] - bool, enable clearing button when an option is selected, default = true
  * [...rest] - any div element properties
  */
 
@@ -163,9 +164,13 @@ export const Icons = () => {
           <p>Default</p>
           <DropdownSelect data={sampleDataIcons} endIcon={<ArrowDown size='md'/>} placeholder='Select an option'/>
         </div>
-        <div>
+        <div className='mr-5'>
           <p>Large</p>
           <DropdownSelect data={sampleDataIconsLarge} size='lg' endIcon={<ArrowDown size='lg'/>} placeholder='Select an option'/>
+        </div>
+        <div>
+          <p>Clearing disabled</p>
+          <DropdownSelect data={sampleDataIconsLarge} size='lg' endIcon={<ArrowDown size='lg' />} allowClear={false} placeholder='Select an option' />
         </div>
       </div>
     </>


### PR DESCRIPTION
this prop allows us to control whether the "x" clear button appears when an option is selected in the dropdown.

One example for a request for this feature is [here](https://eqworks.slack.com/archives/CEYJ4EGGN/p1640186148034800?thread_ts=1640127893.031800&cid=CEYJ4EGGN)