### PR TITLE
[G2M] Dropdown - uncontrolled prop defaults to false

### DIFF
--- a/src/components/dropdown-select.js
+++ b/src/components/dropdown-select.js
@@ -356,7 +356,7 @@ DropdownSelect.defaultProps = {
   data: [],
   button: null,
   size: 'md',
-  uncontrolled: true,
+  uncontrolled: false,
   onSelect: () => {},
   onDelete: () => {},
   startIcon: null,


### PR DESCRIPTION
correcting an oversight made in #65, allowing for a more natural prop interface for the `DropdownSelect` component.

This change would mean that if we wanted an uncontrolled `DropdownSelect`, we would use 

```jsx
<DropdownSelect uncontrolled
  ...
/>
```
... and the absence of the `uncontrolled` prop would mean that we have a controlled select.

If, instead, we want the component to be uncontrolled by default, I suggest we rename the prop to `controlled` and invert the bool logic.

