### PR TITLE
[G2M] tailwind - don't purge z-index utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.23",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     safelist: [
       /^(bg|text|border|shadow)-(primary|secondary|neutral|interactive|success|warning|error|info)/,
       /^(hover|focus|active):(bg|text|border|shadow)-(primary|secondary|neutral|interactive|success|warning|error|info)/,
+      /^z-(.*)/,
     ],
   },
   presets: [],


### PR DESCRIPTION
[ref](https://eqworks.slack.com/archives/C028PTM6H4Z/p1642007342002900)

Without this change, only `z-10` and `z-20` are available to use in lumen-labs `classes` component styling. 

This is kind of a band-aid solution for some styling needed in EQWorks/common-login#26 -- maybe we can discuss how to address this problem in a more robust way re: the conversation linked above 