### PR TITLE
[G2M] progressbar/linear animation

### DIFF
--- a/src/components/progress-bar.js
+++ b/src/components/progress-bar.js
@@ -1,38 +1,51 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 
-import { makeStyles } from '../utils/make-styles'
+import { makeStyles, LinearAnimation } from '../utils/make-styles'
 
 
-const ProgressBar = forwardRef(({ classes, percentage, ...rest }, ref) => {
+const ProgressBar = forwardRef(({
+  classes, animate, direction, duration, progress, ...rest
+}, ref) => {
   const progressBarClasses = Object.freeze({ 
     root: `h-5px w-full bg-primary-100 ${classes.root}`,
     content: `h-full bg-primary-500 ${classes.content}`,
   })
-
   const style = makeStyles({
     progressBarContent: {
-      width: `${percentage}%`,
+      width: `${progress}%`,
     },
   })
 
   return (
     <div ref={ref} className={progressBarClasses.root} {...rest}>
-      <div className={`${progressBarClasses.content} ${style.progressBarContent}`} />
+      {animate && <LinearAnimation
+        width={progress}
+        direction={direction}
+        duration={duration}
+        className={progressBarClasses.content}
+      />}
+      {!animate && (
+        <div className={`${progressBarClasses.content} ${style.progressBarContent}`} />
+      )}
     </div>
   )
 })
 
 ProgressBar.propTypes = {
   classes: PropTypes.object,
-  percentage: PropTypes.number.isRequired,
+  animate: PropTypes.bool,
+  direction: PropTypes.string,
+  duration: PropTypes.number,
+  progress: PropTypes.number,
 }
 
 ProgressBar.defaultProps = {
-  classes: { 
-    root: '', 
-    content: '', 
-  },
+  classes: { root: '', content: '' },
+  animate: false,
+  direction: 'rtl',
+  duration: 10,
+  progress: 100,
 }
 
 ProgressBar.displayName = 'ProgressBar'

--- a/src/components/toast.js
+++ b/src/components/toast.js
@@ -118,22 +118,35 @@ const Toast = forwardRef(({
   const [progress, setProgress] = useState(100)  
 
   useEffect(() => {
+    if (open && timeOut) {
+      const t = setTimeout(() => {
+        if (onTimeOut) {
+          onTimeOut()
+        }
+        onClose()
+      }, timeOut)
+  
+      return () => clearTimeout(t)
+    }
+  }, [open, timeOut])
+
+  useEffect(() => {
     if (timeOut > 0) {
       const toastEl = toastRef.current
       let fade = ''
 
-      if (open) {
-        interval = setInterval(() => {
-          setProgress((prev) => prev - 1)
-        }, (timeOut) / 100)
+      // if (open) {
+      // interval = setInterval(() => {
+      //   setProgress((prev) => prev - 1)
+      // }, (timeOut) / 100)
 
-        timer = setTimeout(() => {
-          if (onTimeOut) onTimeOut()
-          onClose()
-          clearInterval(interval)
-          setProgress(100)
-        }, timeOut + 500)
-      }
+      // timer = setTimeout(() => {
+      //   if (onTimeOut) onTimeOut()
+      //   onClose()
+      //   clearInterval(interval)
+      //   setProgress(100)
+      // }, timeOut + 500)
+      // }
 
       if (toastEl && open) {
         fade = setTimeout(() => {
@@ -177,7 +190,14 @@ const Toast = forwardRef(({
           endIcon={<Close size='sm' onClick={handleOnClose}/>} 
           {...rest}
         >
-          {(timeOut > 0 && (progress >= 0 && progress < 100)) && <ProgressBar classes={progressBarClasses} percentage={progress}/>}
+          {/* {(timeOut > 0 && (progress >= 0 && progress < 100)) && <ProgressBar classes={progressBarClasses} progress={progress}/>} */}
+          <ProgressBar
+            animate
+            direction='ltr'
+            progress={open && timeOut ? 100 : 0}
+            duration={timeOut/1000}
+            classes={progressBarClasses}
+          />
         </ToastBase>
       </div>
     </>

--- a/src/index.js
+++ b/src/index.js
@@ -26,4 +26,4 @@ export { default as Modal } from './components/modal'
 export { default as Tooltip } from './components/tooltip'
 export { default as ProgressBar } from './components/progress-bar'
 
-export { makeStyles } from './utils/make-styles'
+export { makeStyles, LinearAnimation } from './utils/make-styles'

--- a/src/utils/make-styles.js
+++ b/src/utils/make-styles.js
@@ -1,7 +1,27 @@
-import { css } from 'goober'
+import React from 'react'
+import { setup, css, styled, keyframes } from 'goober'
 
+
+setup(React.createElement)
 
 export const makeStyles = (classObj) => Object.entries(classObj).reduce((acc, [key, val]) => {
   acc[key] = css(val)
   return acc
 }, {})
+
+const linear = (width) => ({
+  rtl: keyframes`
+    from { width: 0%; }
+    to { width: ${width}%; }
+  `,
+  ltr: keyframes`
+    from { width: ${width}%; }
+    to { width: 0%; }
+  `,
+})
+
+export const LinearAnimation = styled('div')((props) => ({
+  height: '100%',
+  width: `${props.width}%`,
+  animation: `${linear(props.width)[props.direction]} ${props.duration}s linear`,
+}))

--- a/stories/progress-bar.stories.js
+++ b/stories/progress-bar.stories.js
@@ -12,7 +12,12 @@ export default {
  * [classes] - object, custom styling supported keys:
  *    root: progress bar main container div
  *    content: content / progress bar filler container div
- * [percentage] - number, defines the progress of the progress bar
+ * [progress] - number, defines the percentage of the progress bar
+ * [animate] - boolean, simple linear animation with css
+ * [direction] - string, defines linear animation direction if [animate] is true:
+ *    rtl - right to left
+ *    ltr - left to right
+ * [duration] - number, duration (in seconds) of the animation if [animate] is true
  * [...rest] - any div element properties
  */
 
@@ -42,7 +47,7 @@ export const Normal = () => {
 
   return (
     <>
-      <ProgressBar percentage={progress}/>
+      <ProgressBar progress={progress}/>
       <button onClick={() => setRunning(!running)}>run</button>
     </>
   )


### PR DESCRIPTION
**Changes**:
- add [animate] toggle to current ProgressBar component
- add example animated ProgressBar component usage in Toast component
- renamed [percentage] prop to [progress] for ProgressBar component

**Notes**:
- depends on #77 
- gives alternative animation via css instead of `setInterval`, in attempt to smooth the progress action ([mentioned here](https://github.com/EQWorks/lumen-labs/pull/77#pullrequestreview-848003173))
- not very flexible in terms of usage at this stage, open to improvements

TODO:
- inconsistency of `open && timeOut` (flashes of full progress bar)