### PR TITLE
[G2M] Lint fixes - removed unnecessary prop; moved css imports to top 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.72",
+  "version": "0.1.0-alpha.73",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/components/skeleton/article.js
+++ b/src/components/skeleton/article.js
@@ -20,7 +20,6 @@ const Article = forwardRef(({ title, article }, ref) => (
 Article.propTypes = {
   title: PropTypes.string,
   article: PropTypes.string,
-  ref: PropTypes.forwardRef,
 }
 Article.defaultProps = {
   title: '',

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Radio+Canada:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -12,7 +16,3 @@
     transform: translateX(-100%);
   }
 }
-
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700;800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Radio+Canada:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap');


### PR DESCRIPTION
**Changes:**
- Removed unnecessary prop from Article propTypes
- Moved all CSS imports to the top of each file. This is addressing a specific warning thrown by Vite during development.

![Screenshot 2023-01-09 at 9 40 00 AM](https://user-images.githubusercontent.com/18343242/211334034-c2739cf8-245b-4f62-92df-b1a033eaa934.png)
