### PR TITLE
[G2M] navbar - bug - get displayName directly from child.type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.80",
+  "version": "0.1.0-alpha.81",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/components/navbar/index.js
+++ b/src/components/navbar/index.js
@@ -17,14 +17,20 @@ const Navbar = forwardRef(({ children, classes, ...rest }, ref) => {
       {...rest}
     >
       {React.Children.map(children, (child) => {
-        if (React.isValidElement(child) && child.type.__docgenInfo.displayName === 'NavbarHeader') {
+        if (React.isValidElement(child)
+          && (child.type.__docgenInfo?.displayName === 'NavbarHeader'
+          || child.type.displayName === 'NavbarHeader')
+        ) {
           return React.cloneElement(child)
         }
       })}
 
       <div className={navbarClasses.items}>
         {React.Children.map(children, (child) => {
-          if (React.isValidElement(child) && child.type.__docgenInfo.displayName === 'NavbarItem') {
+          if (React.isValidElement(child)
+            && (child.type.__docgenInfo?.displayName === 'NavbarItem'
+            || child.type.displayName === 'NavbarItem')
+          ) {
             return React.cloneElement(child)
           }
         })}
@@ -33,8 +39,10 @@ const Navbar = forwardRef(({ children, classes, ...rest }, ref) => {
       {React.Children.map(children, (child) => {
         if (
           React.isValidElement(child)
-          && child.type.__docgenInfo.displayName !== 'NavbarHeader'
-          && child.type.__docgenInfo.displayName !== 'NavbarItem'
+          && child.type.__docgenInfo?.displayName !== 'NavbarHeader'
+          && child.type.displayName !== 'NavbarHeader'
+          && child.type.__docgenInfo?.displayName !== 'NavbarItem'
+          && child.type.displayName !== 'NavbarItem'
         ) {
           return React.cloneElement(child)
         }


### PR DESCRIPTION

### Changes:
- fix error: [TypeError: Cannot read properties of undefined (reading 'displayName')](https://vercel.com/eqworks/paymi-web-app/EVNvXwf8f6wBd224rSJ86sUCG9gm)

In Storybook, the `__docgenInfo` property is added to the component object by the `react-docgen` library, which analyzes the component's source code and extracts its prop types and other metadata. This metadata includes the `displayName` property, which is why you can access it as `child.type.__docgenInfo.displayName` in Storybook.

Next.js, on the other hand, uses the `babel-plugin-react-docgen` Babel plugin to generate documentation for React components. This plugin generates the metadata as part of the component's code, which means that the `displayName` property is directly accessible as `child.type.displayName` in Next.js.

So, the reason why you need to use `child.type.__docgenInfo.displayName` in Storybook is that the `displayName` property is stored in the `__docgenInfo` property, which is generated by a library at runtime. In Next.js, the `displayName` property is stored directly in the component code, which means that it is directly accessible as `child.type.displayName`.