### PR TITLE
[G2M] Footer - add download section for links & message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.86",
+  "version": "0.1.0-alpha.87",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/modules/footer.js
+++ b/src/modules/footer.js
@@ -51,6 +51,10 @@ const Footer = ({
     social: '',
     socialIconButtons: '',
     socialIcon: '',
+    downloadContainer: '',
+    downloadLinkContainer: '',
+    downloadLink: '',
+    downloadMessage: '',
     links: '',
     quickLinkHeading: '',
     linkList: '',
@@ -61,6 +65,8 @@ const Footer = ({
   description = '',
   copyrightMessage = '',
   socialIcons = [],
+  downloadLinks = [],
+  downloadMessage = '',
   quickLinks = [],
   customLinks = [],
   type = 'horizontal',
@@ -75,6 +81,10 @@ const Footer = ({
     socialIconButtons: `footer__socialIconButtons-container ${classes.socialIconButtons} focus:outline-none inline-flex justify-center
     items-center cursor-pointer bg-primary-800 border border-primary-800 hover:border-primary-100 active:bg-primary-900 text-secondary-50`,
     socialIcon: `footer__socialIcon-container ${classes.socialIcon}`,
+    downloadContainer: `footer__download-container ${classes.downloadContainer}`,
+    downloadLinkContainer: `footer__download-link-container ${classes.downloadLinkContainer}`,
+    downloadLink: `footer__download-link ${classes.downloadLink}`,
+    downloadMessage: `footer__download-message ${classes.downloadMessage}`,
     links: `footer__links-container ${classes.links} inline-flex justify-between`,
     quickLinkHeading: `footer__quickLinkHeading-container ${classes.quickLinkHeading} uppercase font-bold text-secondary-200`,
     linkList: `footer__linkList-container ${classes.linkList} list-none`,
@@ -88,20 +98,42 @@ const Footer = ({
         <div className={`${footerClasses.info} ${styles.infoContainer}`}>
           <div className={`${footerClasses.logo} ${styles.logo}`}>{logo}</div>
           <p className={`${footerClasses.description} ${styles.description}`}>{description}</p>
-          {socialIcons.length > 0 && <div className={`${footerClasses.social}`}>
-            {socialIcons.map(({ Icon, link }, i) => (
-              <button
-                key={i}
-                onClick={() => window.open(link, '_blank')}
-                className={`${footerClasses.socialIconButtons} ${styles.socialIconButtons}`}
-              >
-                <Icon key={i} className={`${footerClasses.socialIcon} ${styles.socialIcons}`} />
-              </button>
-            ))}
-          </div>}
+          {socialIcons.length > 0 &&
+            <div className={`${footerClasses.social}`}>
+              {socialIcons.map(({ Icon, link }, i) => (
+                <button
+                  key={i}
+                  onClick={() => window.open(link, '_blank')}
+                  className={`${footerClasses.socialIconButtons} ${styles.socialIconButtons}`}
+                >
+                  <Icon key={i} className={`${footerClasses.socialIcon} ${styles.socialIcons}`} />
+                </button>
+              ))}
+            </div>
+          }
+          {/* to be used for mobile screens only */}
+          {
+            Array.isArray(downloadLinks)
+            && downloadLinks.length > 0
+            && type === 'horizontal'
+            && <div className={footerClasses.downloadContainer}>
+              <div className={footerClasses.downloadLinkContainer}>
+                {downloadLinks.map((link, i) => (
+                  <div key={i} className={footerClasses.downloadLink}>
+                    {link}
+                  </div>
+                ))}
+              </div>
+              {downloadMessage &&
+                <div className={footerClasses.downloadMessage}>
+                  {downloadMessage}
+                </div>
+              }
+            </div>
+          }
         </div>
 
-        <div className={`${footerClasses.links}`}>
+        <div className={footerClasses.links}>
           {
             Array.isArray(quickLinks)
             && quickLinks.length > 0
@@ -179,6 +211,8 @@ Footer.propTypes = {
   logo: PropTypes.element.isRequired,
   description: PropTypes.string,
   socialIcons: PropTypes.array,
+  downloadLinks: PropTypes.array,
+  downloadMessage: PropTypes.string,
   copyrightMessage: PropTypes.string,
   quickLinks: PropTypes.array,
   customLinks: PropTypes.array,

--- a/stories/modules/footer.stories.js
+++ b/stories/modules/footer.stories.js
@@ -142,7 +142,6 @@ export const CustomStyle = () => (
 const customLinkStyle = makeStyles({
   root: {
     minHeight: '0rem',
-    height: '12.5rem',
     paddingLeft: '7.5rem',
     paddingRight: '7.5rem',
     paddingTop: '2.547rem',
@@ -156,6 +155,22 @@ const customLinkStyle = makeStyles({
   },
   logo: {
     height: 'auto',
+  },
+  downloadContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '1rem',
+  },
+  downloadLinkContainer: {
+    display: 'flex',
+    gap: '2rem',
+  },
+  downloadLink: {
+    color: 'yellow',
+  },
+  downloadMessage: {
+    color: 'white',
+    marginBottom: '1rem',
   },
   links: {
     width: 'fit-content',
@@ -194,11 +209,17 @@ export const CustomLinks = () => (
     type='horizontal'
     customLinks={['Link 1', 'Link 2']}
     description='Lorem ipsum dolor sit amet.'
+    downloadLinks={['Download1', 'Download2']}
+    downloadMessage='Lorem ipsum dolor sit amet.'
     copyrightMessage='© 2023 Company. All rights reserved.'
     classes={{
       root: customLinkStyle.root,
       content: customLinkStyle.content,
       logo: customLinkStyle.logo,
+      downloadContainer: customLinkStyle.downloadContainer,
+      downloadLinkContainer: customLinkStyle.downloadLinkContainer,
+      downloadLink: customLinkStyle.downloadLink,
+      downloadMessage: customLinkStyle.downloadMessage,
       links: customLinkStyle.links,
       quickLinks: customLinkStyle.quickLinks,
       copyrightMsg: customLinkStyle.copyrightMsg,


### PR DESCRIPTION
https://www.notion.so/eqproduct/Lumen-labs-Footer-add-sections-for-mobile-app-download-buttons-info-6b5cdfe5b2f84f39915238abeebab7ae?pvs=4

**Changes:**

### Footer

- [ ] added section for mobile download app buttons & message as required in the Paymi Figma design

<img width="1176" alt="Screen Shot 2023-05-17 at 9 37 56 AM" src="https://github.com/EQWorks/lumen-labs/assets/41120953/28927439-863c-44b5-8d12-6efe7f0c8456">

Figma:

<img width="415" alt="238968205-7353d1cb-b6b1-4ce0-b124-2f708be76a33" src="https://github.com/EQWorks/lumen-labs/assets/41120953/b967b3e5-ac14-406a-b70a-6f790c200af1">


[Story](https://60d0cd6c298707003972699d-ffkfbzfudw.chromatic.com/?path=/story/modules-footer--custom-links)