### PR TITLE
[G2M] Display Name - Get displayName directly from child.type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.93",
+  "version": "0.1.0-alpha.94",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/lumen-labs",
-  "version": "0.1.0-alpha.92",
+  "version": "0.1.0-alpha.93",
   "description": "",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/components/accordion/index.js
+++ b/src/components/accordion/index.js
@@ -33,12 +33,18 @@ const Accordion = ({
       [borderColor]: _color,
     })} {...props}>
       {React.Children.map(children, (child) => {
-        if (React.isValidElement(child) && child.type.__docgenInfo.displayName === 'Panel') {
+        if (
+          React.isValidElement(child)
+          && (child.type.__docgenInfo.displayName === 'Panel' || child.type.displayName === 'Panel')
+        ) {
           return React.cloneElement(child, { variant, color: _color })
         }
       })}
       {React.Children.map(children, (child) => {
-        if (React.isValidElement(child) && child.type.__docgenInfo.displayName === 'DetailedPanel') {
+        if (
+          React.isValidElement(child)
+          && (child.type.__docgenInfo.displayName === 'DetailedPanel' || child.type.displayName === 'DetailedPanel')
+        ) {
           return React.cloneElement(child)
         }
       })}

--- a/src/components/accordion/index.js
+++ b/src/components/accordion/index.js
@@ -35,7 +35,7 @@ const Accordion = ({
       {React.Children.map(children, (child) => {
         if (
           React.isValidElement(child)
-          && (child.type.__docgenInfo.displayName === 'Panel' || child.type.displayName === 'Panel')
+          && (child.type.__docgenInfo?.displayName === 'Panel' || child.type.displayName === 'Panel')
         ) {
           return React.cloneElement(child, { variant, color: _color })
         }
@@ -43,7 +43,7 @@ const Accordion = ({
       {React.Children.map(children, (child) => {
         if (
           React.isValidElement(child)
-          && (child.type.__docgenInfo.displayName === 'DetailedPanel' || child.type.displayName === 'DetailedPanel')
+          && (child.type.__docgenInfo?.displayName === 'DetailedPanel' || child.type.displayName === 'DetailedPanel')
         ) {
           return React.cloneElement(child)
         }

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -70,7 +70,7 @@ const Tabs = forwardRef(({
         {React.Children.map(children, (child) => {
           if (
             React.isValidElement(child)
-          && child.type.__docgenInfo.displayName === 'Panel'
+          && (child.type.__docgenInfo.displayName === 'Panel' || child.type.displayName === 'Panel')
           && child.props.id === selected
           ) {
             return React.cloneElement(child)

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -70,7 +70,7 @@ const Tabs = forwardRef(({
         {React.Children.map(children, (child) => {
           if (
             React.isValidElement(child)
-          && (child.type.__docgenInfo.displayName === 'Panel' || child.type.displayName === 'Panel')
+          && (child.type.__docgenInfo?.displayName === 'Panel' || child.type.displayName === 'Panel')
           && child.props.id === selected
           ) {
             return React.cloneElement(child)


### PR DESCRIPTION
https://www.notion.so/eqproduct/Lumen-Labs-DisplayName-Bug-0de7f0c584cf4ad1bb585cf89fc9a6ea?pvs=4

**Changes**
- Implemented changes from the [following](https://github.com/EQWorks/lumen-labs/pull/190) to allow Tabs and Accordion component to be compatible with Next.js