### PR TITLE
[G2M] devops - Updated workflow to use actions

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,13 +1,22 @@
 name: Storybook Build & Deploy
 
 on:
+  workflow_dispatch: # just added for testing purposes
   push:
     branches:
       - main
 
 jobs:
   build-and-deploy:
+    # Grant GITHUB_TOKEN/token the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+      contents: read
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.build-publish.outputs.page_url }}
 
     steps:
       - uses: actions/checkout@v3
@@ -23,8 +32,14 @@ jobs:
       - run: yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
-      - run: yarn build-storybook
-      - name: Deploy to GitHub pages
-        run: yarn storybook-to-ghpages --ci
-        env:
-          GH_TOKEN: EQWorks:${{ secrets.CD_GITHUB_TOKEN }}
+          
+      - name: Upload
+        uses: actions/upload-pages-artifact@v1.0.8
+        with: 
+          path: github-pages
+  
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v1
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -2,8 +2,6 @@ name: Storybook Build & Deploy
 
 on:
   push:
-    tags:
-      - 's*-alpha*' # just added for testing PURPOSES
     branches:
       - main
 

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,8 +1,9 @@
 name: Storybook Build & Deploy
 
 on:
-  workflow_dispatch: # just added for testing purposes
   push:
+    tags:
+      - 'v*-alpha*' # just added for testing PURPOSES
     branches:
       - main
 

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.build-publish.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - uses: actions/checkout@v3
@@ -31,14 +31,18 @@ jobs:
       - run: yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
-          
+      
+      - name: Build Storybook
+        run: |
+          yarn build-storybook --output-dir github-pages
+
       - name: Upload
         uses: actions/upload-pages-artifact@v1.0.8
         with: 
           path: github-pages
   
       - name: Deploy to GitHub Pages
-        id: deploy
+        id: deployment
         uses: actions/deploy-pages@v1
         with:
           token: ${{ github.token }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -3,7 +3,7 @@ name: Storybook Build & Deploy
 on:
   push:
     tags:
-      - 'v*-alpha*' # just added for testing PURPOSES
+      - 's*-alpha*' # just added for testing PURPOSES
     branches:
       - main
 


### PR DESCRIPTION
https://www.notion.so/eqproduct/fix-Lumen-labs-storybook-deployment-12155b47af7d4df3af9ef297513617c5?pvs=4

Changes/Fixes:
- Now the deployment will be based on a gh actions rather than branch based, [ref](https://github.com/marketplace/actions/deploy-github-pages-site#security-considerations) and also, do note that this is still in beta but we are already using it in [paymi-hooks repo](https://github.com/EQWorks/paymi-hooks/blob/59163752b377591b931079cac4dc6719620dd838/.github/workflows/storybook-deploy.yml#L52).

